### PR TITLE
Improve translation quality by providing surrounding context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here are some things I hope to add in the future:
 
 Here are some things that PubNL Translator is not able to do, and which I don't expect it to be able to do in the future:
 
-- Each line is translated separately, so the context may get lost in translation.
+- Lines are translated in batches, so some context may get lost in translation.
 - PubNL Translator cannot translate live broadcasts.
 - PubNL Translator depends on the original subtitles of a video. If there were no subtitles originally, there will be no translated subtitles. Likewise, if the timing of the original subtitles is off, the timing of the translated subtitles will be off as well.
 

--- a/js/translate-webvtt.js
+++ b/js/translate-webvtt.js
@@ -3,6 +3,7 @@
 import { GoogleTranslateV1Translator } from "./translation-engines/google-translate-v1.js";
 
 const LINE_LENGTH_CUTOFF = 35;
+const BATCH_SIZE = 5;
 
 function getFormattedChunk(remainder) {
   const hasFormattingRegex = RegExp("(<.+?>).*?</.+?>");
@@ -31,7 +32,7 @@ function getFormattedChunk(remainder) {
   // We extract all consecutive parts that have the same formatting.
   chunk.tag = { open: formattingMatch[1], close: `</${formattingMatch[1].match(tagNameRegex)[1]}>` };
   const formattedChunkRegex = RegExp(String.raw`^(${chunk.tag.open}.*?${chunk.tag.close}\s*)`);
-  for (;;) {
+  for (; ;) {
     let chunkMatch = remainder.text.match(formattedChunkRegex);
 
     if (!chunkMatch) {
@@ -79,20 +80,54 @@ function splitLongText(text) {
   return [text];
 }
 
-async function translateCue(text, sourceLanguage, targetLanguage) {
+function extractChunksFromCue(text) {
   let remainder = { text: text.replaceAll("\n", " ") };
-  let translatedCueLines = [];
-  const translator = new GoogleTranslateV1Translator();
+  let chunks = [];
 
   while (remainder.text.length > 0) {
-    // Separate text and formatting.
     const chunk = getFormattedChunk(remainder);
-    const translated = await translator.translate(chunk.text, sourceLanguage, targetLanguage);
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+async function translateBatch(translator, texts, sourceLanguage, targetLanguage) {
+  if (texts.length === 0) return [];
+  if (texts.length === 1) {
+    return [await translator.translate(texts[0], sourceLanguage, targetLanguage)];
+  }
+
+  const markedText = texts.map((text, i) => `[${i}] ${text}`).join(" ");
+  const translatedMarked = await translator.translate(markedText, sourceLanguage, targetLanguage);
+
+  const result = new Array(texts.length).fill("");
+  const matches = [...translatedMarked.matchAll(/\[(\d+)\]\s*/g)];
+
+  for (let i = 0; i < matches.length; i++) {
+    const idx = parseInt(matches[i][1]);
+    if (idx < 0 || idx >= texts.length) {
+      continue;
+    }
+
+    const start = matches[i].index + matches[i][0].length;
+    const end = matches[i + 1]?.index ?? translatedMarked.length;
+    result[idx] = translatedMarked.substring(start, end).trim();
+  }
+
+  return result;
+}
+
+function reassembleCue(chunks, translatedTexts) {
+  let translatedCueLines = [];
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const translated = translatedTexts[i] || "";
     let multiline = splitLongText(translated);
 
-    // Restore formatting.
-    for (let i = 0; i < multiline.length; i++) {
-      multiline[i] = `${chunk.tag.open}${multiline[i]}${chunk.tag.close}`;
+    for (let j = 0; j < multiline.length; j++) {
+      multiline[j] = `${chunk.tag.open}${multiline[j]}${chunk.tag.close}`;
     }
 
     translatedCueLines.push(multiline.join("\n"));
@@ -102,8 +137,8 @@ async function translateCue(text, sourceLanguage, targetLanguage) {
 }
 
 function cueToString(cue, text) {
-  const startTime = new Date(Math.round(cue.startTime * 1000)).toISOString().match("T(.*)Z$")[1];
-  const endTime = new Date(Math.round(cue.endTime * 1000)).toISOString().match("T(.*)Z$")[1];
+  const startTime = new Date(Math.round(cue.startTime * 1000)).toISOString().match("T(.*)Z$")?.[1] ?? "";
+  const endTime = new Date(Math.round(cue.endTime * 1000)).toISOString().match("T(.*)Z$")?.[1] ?? "";
   const line = cue.line ? ` line:${cue.line}%` : "";
   const position = cue.position ? ` position:${cue.position}%` : "";
   const align = cue.align ? ` align:${cue.align.replace("middle", "center")}` : "";
@@ -143,17 +178,26 @@ function parseWebVTT(input) {
 
 export async function translateWebVTT(input, sourceLanguage, targetLanguage, progressFunction) {
   const cues = parseWebVTT(input);
-  const cueNum = cues.length;
+  const translator = new GoogleTranslateV1Translator();
 
-  let translatedCues = Array(cues.length);
-  for (let i = 0; i < cueNum; i++) {
-    translatedCues[i] = translateCue(cues[i].text, sourceLanguage, targetLanguage);
+  const cueChunks = cues.map(cue => extractChunksFromCue(cue.text));
+  const allTexts = cueChunks.flat().map(c => c.text);
+  const translatedTexts = [];
+
+  for (let i = 0; i < allTexts.length; i += BATCH_SIZE) {
+    const batch = allTexts.slice(i, i + BATCH_SIZE);
+    const translated = await translateBatch(translator, batch, sourceLanguage, targetLanguage);
+    translatedTexts.push(...translated);
+    progressFunction((translatedTexts.length / allTexts.length) * 100);
   }
 
+  let offset = 0;
   let translatedWebVTT = "WEBVTT\n\n";
-  for (let i = 0; i < cueNum; i++) {
-    translatedWebVTT += cueToString(cues[i], await translatedCues[i]);
-    progressFunction(((i + 1) / cueNum) * 100);
+  for (let i = 0; i < cues.length; i++) {
+    const chunks = cueChunks[i];
+    const texts = translatedTexts.slice(offset, offset + chunks.length);
+    offset += chunks.length;
+    translatedWebVTT += cueToString(cues[i], reassembleCue(chunks, texts));
   }
 
   return translatedWebVTT;


### PR DESCRIPTION
Hello Thom,

I'm Dutch too but I'll write in English as the lingua franca. Thanks for making this add-on, it's so helpful for my girlfriend to learn Dutch. She noticed the translation can be off sometimes because, as you admitted in the readme, the context is missing. So here's my attempt to improve it, by:

- Batching multiple subtitle texts together before translating, in order to give the translator more context for better quality translations
- It does this by using numbered markers [1], [2] etc. to combine texts and parse them back after translation
- Refactored cue translation into separate extraction & reassembly steps
- Additional benefits: fewer API calls

I've only tested it with Dutch → English, but it seems to work smoothly! Here is a test result with yesterday's NOS Journaal:

###  1. Better recognition of idiomatic expressions:

> "[Een pijnlijk spoeddebat over de mest-ruzie in het kabinet.] Vanavond moet blijken hoe hoog dit oploopt."

→ 
Originally:

> "Tonight it will become clear **how high this will amount to**."

Now:

> "Tonight it will become clear **how far this will escalate**."

### 2. Correctly identify pronouns ("ze" can be both "them" or "she/her"):

> "Some members of the House of Representatives are already discussing possibly sending **them** home."

→

> "Some members of the House of Representatives are already discussing possibly sending **her** home."

### 3. Improved idiom:

> "In the end, my employer only needed **half a word**."

→

> "My employer ultimately needed only **a few words**."

### 4. Idiom is no longer lost in translation:

And, previously it didn’t translate a particular line at all (it just returned a dot). It now gives:

> "put them in the sun for a while."

("ze in het zonnetje zetten" 😅 ok, close enough to English "put them in the spotlight")

I noticed a minimum of `BATCH_SIZE = 5` gives the best translation results.

View the complete differences by running `diff batch_size_1.txt batch_size_5.txt` (note: a batch size of 1 or 2 gave exactly the same results).

[batch_size_1.txt](https://github.com/user-attachments/files/24229969/batch_size_1.txt)
[batch_size_2.txt](https://github.com/user-attachments/files/24229970/batch_size_2.txt)
[batch_size_3.txt](https://github.com/user-attachments/files/24229971/batch_size_3.txt)
[batch_size_4.txt](https://github.com/user-attachments/files/24229973/batch_size_4.txt)
[batch_size_5.txt](https://github.com/user-attachments/files/24229974/batch_size_5.txt)